### PR TITLE
Add dark mode toggle

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import "./globals.css";
 import { Sidebar } from "@/components/Sidebar";
 import { Topbar } from "@/components/Topbar";
+import { Providers } from "@/components/Providers";
 
 export default function RootLayout({
   children,
@@ -9,14 +10,16 @@ export default function RootLayout({
 }) {
   return (
     <html lang="en">
-      <body className="bg-gray-50">
-        <div className="flex h-screen overflow-hidden">
-          <Sidebar />
-          <div className="flex-1 flex flex-col min-w-0">
-            <Topbar />
-            <main className="flex-1 overflow-y-auto p-8">{children}</main>
+      <body>
+        <Providers>
+          <div className="flex h-screen overflow-hidden">
+            <Sidebar />
+            <div className="flex-1 flex flex-col min-w-0">
+              <Topbar />
+              <main className="flex-1 overflow-y-auto p-8">{children}</main>
+            </div>
           </div>
-        </div>
+        </Providers>
       </body>
     </html>
   );

--- a/src/app/tasks/page.tsx
+++ b/src/app/tasks/page.tsx
@@ -345,7 +345,7 @@ export default function TasksPage() {
         setShowModal={setShowAddContainerModal}
       >
         <div className="flex flex-col w-full items-start gap-y-4">
-          <h1 className="text-gray-800 text-3xl font-bold">Add Container</h1>
+          <h1 className="text-gray-800 dark:text-gray-100 text-3xl font-bold">Add Container</h1>
           <Input
             type="text"
             placeholder="Container Title"
@@ -359,7 +359,7 @@ export default function TasksPage() {
       {/* Add Item Modal */}
       <Modal showModal={showAddItemModal} setShowModal={setShowAddItemModal}>
         <div className="flex flex-col w-full items-start gap-y-4">
-          <h1 className="text-gray-800 text-3xl font-bold">Add Item</h1>
+          <h1 className="text-gray-800 dark:text-gray-100 text-3xl font-bold">Add Item</h1>
           <Input
             type="text"
             placeholder="Item Title"
@@ -371,7 +371,7 @@ export default function TasksPage() {
         </div>
       </Modal>
       <div className="flex items-center justify-between gap-y-2">
-        <h1 className="text-gray-800 text-3xl font-bold">Tasks Kanban Board</h1>
+        <h1 className="text-gray-800 dark:text-gray-100 text-3xl font-bold">Tasks Kanban Board</h1>
         <Button onClick={() => setShowAddContainerModal(true)}>
           Add Container
         </Button>

--- a/src/components/NavItem.tsx
+++ b/src/components/NavItem.tsx
@@ -17,8 +17,8 @@ export function NavItem({ href, icon, label }: NavItemProps) {
       className={cn(
         "flex items-center gap-3 px-4 py-2 rounded-xl font-medium transition-colors",
         active
-          ? "bg-blue-100 text-blue-600"
-          : "hover:bg-blue-50 text-gray-700"
+          ? "bg-blue-100 dark:bg-blue-700 text-blue-600 dark:text-blue-100"
+          : "hover:bg-blue-50 dark:hover:bg-gray-800 text-gray-700 dark:text-gray-300"
       )}
       aria-current={active ? "page" : undefined}
     >

--- a/src/components/Providers.tsx
+++ b/src/components/Providers.tsx
@@ -1,0 +1,7 @@
+'use client'
+
+import { ThemeProvider } from './theme-provider'
+
+export function Providers({ children }: { children: React.ReactNode }) {
+  return <ThemeProvider>{children}</ThemeProvider>
+}

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -12,14 +12,18 @@ const NAV_LINKS = [
 
 export function Sidebar() {
   return (
-    <aside className="w-56 bg-white h-full border-r flex flex-col gap-2 p-4">
-      <div className="mb-8"><Logo /></div>
+    <aside
+      className="w-56 bg-white dark:bg-gray-900 text-gray-800 dark:text-gray-100 h-full border-r border-gray-200 dark:border-gray-700 flex flex-col gap-2 p-4"
+    >
+      <div className="mb-8">
+        <Logo />
+      </div>
       <nav className="flex-1 flex flex-col gap-1">
-        {NAV_LINKS.map(link => (
+        {NAV_LINKS.map((link) => (
           <NavItem key={link.href} {...link} />
         ))}
       </nav>
       {/* Could add workspace switcher, help, settings, etc. */}
     </aside>
-  );
+  )
 }

--- a/src/components/Topbar.tsx
+++ b/src/components/Topbar.tsx
@@ -1,10 +1,14 @@
 import { UserMenu } from "./UserMenu";
 export function Topbar() {
   return (
-    <header className="h-16 bg-white border-b flex items-center justify-between px-8">
+    <header
+      className="h-16 bg-white dark:bg-gray-900 border-b border-gray-200 dark:border-gray-700 flex items-center justify-between px-8"
+    >
       {/* Could add breadcrumbs, search, notifications, etc. */}
-      <div className="text-lg font-semibold text-gray-800">Dashboard</div>
+      <div className="text-lg font-semibold text-gray-800 dark:text-gray-100">
+        Dashboard
+      </div>
       <UserMenu />
     </header>
-  );
+  )
 }

--- a/src/components/UserMenu.tsx
+++ b/src/components/UserMenu.tsx
@@ -1,3 +1,5 @@
+"use client"
+
 import { Avatar } from "@/components/ui/avatar"; // shadcn/ui avatar
 import { Sun, Moon } from "lucide-react";
 import { useTheme } from "@/components/theme-provider";

--- a/src/components/UserMenu.tsx
+++ b/src/components/UserMenu.tsx
@@ -1,12 +1,23 @@
 import { Avatar } from "@/components/ui/avatar"; // shadcn/ui avatar
+import { Sun, Moon } from "lucide-react";
+import { useTheme } from "@/components/theme-provider";
 export function UserMenu() {
+  const { theme, toggleTheme } = useTheme()
+
   return (
     <div className="flex items-center gap-2 cursor-pointer">
       <Avatar>
         <img src="https://i.pravatar.cc/40" alt="User avatar" />
       </Avatar>
-      <span className="font-medium text-gray-700">Jane Doe</span>
+      <span className="font-medium text-gray-700 dark:text-gray-200">Jane Doe</span>
+      <button
+        aria-label="Toggle theme"
+        onClick={toggleTheme}
+        className="ml-2"
+      >
+        {theme === 'dark' ? <Sun className="size-4" /> : <Moon className="size-4" />}
+      </button>
       {/* Add dropdown for profile/logout as needed */}
     </div>
-  );
+  )
 }

--- a/src/components/tasks/Button/index.tsx
+++ b/src/components/tasks/Button/index.tsx
@@ -15,7 +15,7 @@ const buttonVariants = cva(
           'border border-input bg-background hover:bg-accent hover:text-accent-foreground',
         secondary:
           'bg-secondary text-secondary-foreground hover:bg-secondary/80',
-        ghost: 'hover:bg-gray-100',
+        ghost: 'hover:bg-gray-100 dark:hover:bg-gray-800',
         link: 'text-primary underline-offset-4 hover:underline',
       },
       size: {

--- a/src/components/tasks/Container/index.tsx
+++ b/src/components/tasks/Container/index.tsx
@@ -35,17 +35,17 @@ const Container = ({
         transform: CSS.Translate.toString(transform),
       }}
       className={clsx(
-        'w-full h-full p-4 bg-gray-50 rounded-xl flex flex-col gap-y-4',
+        'w-full h-full p-4 bg-gray-50 dark:bg-gray-800 rounded-xl flex flex-col gap-y-4 border border-gray-200 dark:border-gray-700',
         isDragging && 'opacity-50',
       )}
     >
       <div className="flex items-center justify-between">
         <div className="flex flex-col gap-y-1">
-          <h1 className="text-gray-800 text-xl">{title}</h1>
-          <p className="text-gray-400 text-sm">{description}</p>
+          <h1 className="text-gray-800 dark:text-gray-100 text-xl">{title}</h1>
+          <p className="text-gray-400 dark:text-gray-400 text-sm">{description}</p>
         </div>
         <button
-          className="border p-2 rounded-xl shadow-lg hover:shadow-xl flex items-center justify-center"
+          className="border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900 p-2 rounded-xl shadow-lg hover:shadow-xl flex items-center justify-center"
           {...listeners}
           aria-label="Drag Handle"
         >

--- a/src/components/tasks/Input/index.tsx
+++ b/src/components/tasks/Input/index.tsx
@@ -8,7 +8,7 @@ const Input = ({ name, value, placeholder, onChange }: InputProps) => {
       value={value}
       placeholder={placeholder}
       onChange={onChange}
-      className="border p-2 w-full rounded-lg shadow-lg hover:shadow-xl"
+      className="border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900 text-gray-800 dark:text-gray-100 p-2 w-full rounded-lg shadow-lg hover:shadow-xl"
     ></input>
   );
 };

--- a/src/components/tasks/Item/index.tsx
+++ b/src/components/tasks/Item/index.tsx
@@ -33,7 +33,7 @@ const Items = ({ id, title }: ItemsType) => {
         transform: CSS.Translate.toString(transform),
       }}
       className={clsx(
-        'px-2 py-4 bg-white shadow-md rounded-xl w-full border border-transparent hover:border-gray-200 cursor-pointer',
+        'px-2 py-4 bg-white dark:bg-gray-900 text-gray-800 dark:text-gray-100 shadow-md rounded-xl w-full border border-transparent hover:border-gray-200 dark:hover:border-gray-700 cursor-pointer',
         isDragging && 'opacity-50',
       )}
     >

--- a/src/components/tasks/Modal/index.tsx
+++ b/src/components/tasks/Modal/index.tsx
@@ -50,7 +50,7 @@ export default function Modal({
             >
               <div
                 className={clsx(
-                  `overflow relative w-full max-w-lg transform rounded-xl border border-gray-200 bg-white p-6 text-left shadow-2xl transition-all`,
+                  `overflow relative w-full max-w-lg transform rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900 text-gray-800 dark:text-gray-100 p-6 text-left shadow-2xl transition-all`,
                   containerClasses,
                 )}
               >
@@ -60,7 +60,7 @@ export default function Modal({
           </FocusTrap>
           <motion.div
             key="desktop-backdrop"
-            className="fixed inset-0 z-30 bg-white/30 backdrop-blur-sm"
+            className="fixed inset-0 z-30 bg-white/30 dark:bg-black/60 backdrop-blur-sm"
             initial={{ opacity: 0 }}
             animate={{ opacity: 1 }}
             exit={{ opacity: 0 }}

--- a/src/components/theme-provider.tsx
+++ b/src/components/theme-provider.tsx
@@ -1,0 +1,55 @@
+'use client'
+
+import { createContext, useContext, useEffect, useState } from 'react'
+
+export type Theme = 'light' | 'dark'
+
+interface ThemeContextValue {
+  theme: Theme
+  toggleTheme: () => void
+}
+
+const ThemeContext = createContext<ThemeContextValue | undefined>(undefined)
+
+export function ThemeProvider({ children }: { children: React.ReactNode }) {
+  const [theme, setTheme] = useState<Theme>('light')
+
+  // initialize theme from localStorage or system preference
+  useEffect(() => {
+    if (typeof window === 'undefined') return
+    const stored = (localStorage.getItem('theme') as Theme | null)
+    if (stored) {
+      setTheme(stored)
+    } else if (window.matchMedia('(prefers-color-scheme: dark)').matches) {
+      setTheme('dark')
+    }
+  }, [])
+
+  // apply class and persist
+  useEffect(() => {
+    if (typeof document === 'undefined') return
+    const root = document.documentElement
+    if (theme === 'dark') {
+      root.classList.add('dark')
+    } else {
+      root.classList.remove('dark')
+    }
+    localStorage.setItem('theme', theme)
+  }, [theme])
+
+  const toggleTheme = () => {
+    setTheme((prev) => (prev === 'dark' ? 'light' : 'dark'))
+  }
+
+  return (
+    <ThemeContext.Provider value={{ theme, toggleTheme }}>
+      {children}
+    </ThemeContext.Provider>
+  )
+}
+
+export function useTheme() {
+  const ctx = useContext(ThemeContext)
+  if (!ctx) throw new Error('useTheme must be used within ThemeProvider')
+  return ctx
+}


### PR DESCRIPTION
## Summary
- add a small theme provider with `ThemeProvider` and `useTheme`
- wrap layout in provider so dark styles apply
- add a button in `UserMenu` to toggle between light and dark themes

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_687bed1e64108320a7dda4e4f7d695ac